### PR TITLE
BAH-1020 | Disable text box for auto-computed fields

### DIFF
--- a/src/components/NumericBox.jsx
+++ b/src/components/NumericBox.jsx
@@ -95,6 +95,11 @@ export class NumericBox extends Component {
     return Validator.getErrors(controlDetails);
   }
 
+  isComputed() {
+    const { conceptClass } = this.props;
+    return conceptClass === 'Computed';
+  }
+
   render() {
     const { lowNormal, hiNormal } = this.props;
     if (NumericBoxDesigner.getRange(lowNormal, hiNormal) !== '') {
@@ -119,7 +124,8 @@ export class NumericBox extends Component {
     return (
       <div className="fl">
         <input
-          className={ classNames({ 'form-builder-error': this.state.hasErrors }) }
+          className={ classNames({ 'form-builder-error': this.state.hasErrors,
+            'computed-value': this.isComputed() }) }
           disabled={ !this.props.enabled }
           onChange={ (e) => this.handleChange(e) }
           ref={(elem) => {
@@ -133,6 +139,7 @@ export class NumericBox extends Component {
 }
 
 NumericBox.propTypes = {
+  conceptClass: PropTypes.string,
   enabled: PropTypes.bool,
   formFieldPath: PropTypes.string.isRequired,
   hiAbsolute: PropTypes.number,

--- a/src/components/designer/NumericBoxDesigner.jsx
+++ b/src/components/designer/NumericBoxDesigner.jsx
@@ -7,6 +7,11 @@ export class NumericBoxDesigner extends Component {
     return this.props.metadata;
   }
 
+  isComputed() {
+    const { metadata } = this.props;
+    return metadata.concept && metadata.concept.conceptClass === 'Computed';
+  }
+
   render() {
     const { lowNormal, hiNormal } = this.props;
     if (NumericBoxDesigner.getRange(lowNormal, hiNormal) !== '') {
@@ -21,7 +26,7 @@ export class NumericBoxDesigner extends Component {
     }
     return (
         <div className="fl">
-          <input type="number" />
+            { !this.isComputed() && <input type="number" />}
         </div>
     );
   }

--- a/styles/bahmniAppsFormBuilder/_form.scss
+++ b/styles/bahmniAppsFormBuilder/_form.scss
@@ -622,3 +622,8 @@ $lightestGray: #eee;
   width: 30% !important;
   vertical-align: top;
 }
+
+input.computed-value{
+  border: 0 !important;
+  pointer-events: none;
+}

--- a/test/components/NumericBox.spec.js
+++ b/test/components/NumericBox.spec.js
@@ -14,7 +14,7 @@ describe('NumericBox', () => {
 
   const validations = [constants.validations.allowDecimal, constants.validations.mandatory];
 
-  it('should render NumericBox', () => {
+  it('should render NumericBox with empty class when conceptClass is not Computed', () => {
     const concept = {};
     const wrapper = shallow(
       <NumericBox
@@ -28,8 +28,8 @@ describe('NumericBox', () => {
     );
     expect(wrapper.find('input').props().type).to.be.eql('number');
     expect(wrapper.find('input')).to.have.value(undefined);
+    expect(wrapper.find('input')).to.have.className('');
   });
-
 
   it('should render NumericBox with default value', () => {
     const concept = {};
@@ -46,6 +46,23 @@ describe('NumericBox', () => {
     );
     expect(wrapper.find('input').props().type).to.be.eql('number');
     expect(wrapper.find('input')).to.have.value('50');
+  });
+
+  it('should render NumericBox with computed-value class when conceptClass is Computed', () => {
+    const wrapper = mount(
+      <NumericBox
+        conceptClass="Computed"
+        formFieldPath="test1.1-0"
+        onChange={onChangeSpy}
+        validate={false}
+        validateForm={false}
+        validations={[]}
+        value={'50'}
+      />
+    );
+    expect(wrapper.find('input').props().type).to.be.eql('number');
+    expect(wrapper.find('input')).to.have.value('50');
+    expect(wrapper.find('input')).to.have.className('computed-value');
   });
 
   it('should get user entered value of the NumericBox', () => {
@@ -325,6 +342,7 @@ describe('NumericBox', () => {
     wrapper.instance();
     sinon.assert.calledOnce(spy);
   });
+
   it('should not trigger onChange when mounting component and the value is undefined', () => {
     const spy = sinon.spy();
     const wrapper = mount(

--- a/test/components/designer/NumericBoxDesigner.spec.js
+++ b/test/components/designer/NumericBoxDesigner.spec.js
@@ -29,6 +29,14 @@ describe('NumericBoxDesigner', () => {
     expect(wrapper.find('input').props().type).to.eql('number');
   });
 
+  it('should not render the input when concept class is computed', () => {
+    metadata.concept.conceptClass = 'Computed';
+    wrapper = shallow(<NumericBoxDesigner metadata={metadata} />);
+
+    expect(wrapper).to.not.have.descendants('input');
+  });
+
+
   it('should return json definition', () => {
     const instance = wrapper.instance();
     expect(instance.getJsonDefinition()).to.deep.eql(metadata);


### PR DESCRIPTION
https://bahmni.atlassian.net/browse/BAH-1020

As an administrator,

If a value is computed through some calculations such as BMI

I want to convenience the user such that (s)he does not need to write the text input

Expected behavior: The input field for computed class(eg: BMI) should be disabled.

Actual behavior: The input field for computed class(eg: BMI) is enabled.

 

In scope:

No text input for a concept of type computed when creating the form in FormBuilder

No text input for a concept of type computed when the form is rendered (Consultation page)