### PR TITLE
Added an escape logic for special regular expression characters on form names

### DIFF
--- a/src/helpers/Obs.js
+++ b/src/helpers/Obs.js
@@ -145,12 +145,17 @@ export function obsFromMetadata(formNamespaceAndPath, metadata) {
   });
 }
 
+function escapeRegExp(text) {
+  return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+}
+
 export function createObsFromControl(formName, formVersion, control, bahmniObservations = [],
                                      parentFormFieldPath) {
   const keyPrefix = getKeyPrefixForControl(formName, formVersion, control.id, parentFormFieldPath);
+  const escapedFormFieldPath = escapeRegExp(keyPrefix.formFieldPath);
   const observationsForControl = bahmniObservations.filter(observation =>
     observation.formFieldPath.startsWith(keyPrefix.formFieldPath) &&
-      new RegExp(`${keyPrefix.formFieldPath}[^0-9]`).test(observation.formFieldPath)
+      new RegExp(`${escapedFormFieldPath}[^0-9]`).test(observation.formFieldPath)
   );
   if (observationsForControl.length > 0) {
     return observationsForControl;


### PR DESCRIPTION
Added an escape logic for special regular expression characters for form field path string before using RegExp matching during creation of observation for an obs control.

There is an issue with observations binding to a given form when a form has a parenthesis in its name. To reproduce this issue:

1. Create a form at the implementers interface and add a parenthesis in the forms name ( e.g. test (test form) ) and publish the form
2. Capture an observation using that form and save it
3. When saved the captured observations will fail to bind to the form observation controls

The issue is due to the fact that the parenthesis without being escaped has a special meaning in regular expression and the matching of the form name and observations form field path will fail.