### PR TITLE
fix:  column 2 to 3 table that drags to canvas

### DIFF
--- a/src/components/designer/TableDesigner.jsx
+++ b/src/components/designer/TableDesigner.jsx
@@ -9,7 +9,7 @@ import { CellDesigner } from 'components/designer/Cell.jsx';
 const supportedControlTypes = ['obsControl'];
 const unsupportedProperties = ['addMore'];
 
-const NO_OF_TABLE_COLUMNS = 2;
+const NO_OF_TABLE_COLUMNS = 3;
 
 export class TableDesigner extends Component {
 


### PR DESCRIPTION
Changed number of columns displayed from 2 to 3, in dragging table in canvas.

Pair contributors 👍 
Abhishek Kumar <flashtoak@gmail.com>
Jayanth Sai <njayanthsai@gmail.com>
