### PR TITLE
BAH-2994 - fix the dropdown select issue on IOS devices

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bahmni-form-controls",
-  "version": "0.93.15",
+  "version": "0.93.16",
   "description": "Repository for form controls",
   "license": "GPL-2.0",
   "main": "./dist/bundle.js",

--- a/src/components/AutoComplete.jsx
+++ b/src/components/AutoComplete.jsx
@@ -209,8 +209,8 @@ export class AutoComplete extends Component {
             cache={cache}
             loadOptions={this.getOptions}
             onFocus={this.handleFocus}
+            optionClassName="needsclick"
             ref={this.storeChildRef}
-            optionClassName="needsclick" // to fix the IOS device issue
           />
         </div>
       );
@@ -222,9 +222,9 @@ export class AutoComplete extends Component {
           filterOptions={null}
           noResultsText={this.state.noResultsText}
           onInputChange={this.debouncedOnInputChange}
+          optionClassName="needsclick"
           options={this.state.options}
           ref={this.storeChildRef}
-          optionClassName="needsclick" // to fix the IOS device issue
         />
       </div>
     );

--- a/src/components/AutoComplete.jsx
+++ b/src/components/AutoComplete.jsx
@@ -210,6 +210,7 @@ export class AutoComplete extends Component {
             loadOptions={this.getOptions}
             onFocus={this.handleFocus}
             ref={this.storeChildRef}
+            optionClassName="needsclick" // to fix the IOS device issue
           />
         </div>
       );
@@ -223,6 +224,7 @@ export class AutoComplete extends Component {
           onInputChange={this.debouncedOnInputChange}
           options={this.state.options}
           ref={this.storeChildRef}
+          optionClassName="needsclick" // to fix the IOS device issue
         />
       </div>
     );


### PR DESCRIPTION
The issue is that in IOS devices the onChange handler is not getting invoked after selecting a value from the dropdown menu. Further analysis showed that it is happening due to another library called "fastclick" in openmrs-bahmniapps repo. The "fastclick" library causing this issue with react-select in IOS devices can be found in the below link. 
https://github.com/JedWatson/react-select/issues/2891

**Fix:**
The "fastclick" library provides a way to ignore its effect on a certain element by adding classname "needsclick" to that element. This can be found on their official npm page.
https://www.npmjs.com/package/fastclick
https://github.com/JedWatson/react-select/issues/1036