### PR TITLE
feat: Add SurgicalBlockObsHandler with reusable dynamic URL token resolver

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "react-test-renderer": "^16.12.0",
     "react-textarea-autosize": "^4.0.5",
     "sinon-as-promised": "^4.0.3",
+    "moment": "^2.29.1",
     "whatwg-fetch": "^1.0.0"
   },
   "resolutions": {

--- a/src/components/SurgicalBlock.jsx
+++ b/src/components/SurgicalBlock.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
+import { Util } from 'src/helpers/Util';
 import ComponentStore from 'src/helpers/componentStore';
 import { AutoComplete } from 'src/components/AutoComplete.jsx';
 import { httpInterceptor } from 'src/helpers/httpInterceptor';
@@ -16,16 +17,11 @@ export class SurgicalBlock extends Component {
   }
 
   componentDidMount() {
-    const now = moment();
-    const oneMonthAgo = moment().subtract(1, 'months').startOf('day');
-
-    const startDatetime = encodeURIComponent(oneMonthAgo.format('YYYY-MM-DDTHH:mm:ss.SSSZZ'));
-    const endDatetime = encodeURIComponent(now.endOf('day').format('YYYY-MM-DDTHH:mm:ss.SSSZZ'));
-
-    const url = '/openmrs/ws/rest/v1/surgicalBlock' +
+    const { properties } = this.props;
+    const defaultUrl = '/openmrs/ws/rest/v1/surgicalBlock' +
       '?activeBlocks=true' +
-      `&startDatetime=${startDatetime}` +
-      `&endDatetime=${endDatetime}` +
+      '&startDatetime={NOW-30d}' +
+      '&endDatetime={NOW}' +
       '&includeVoided=false' +
       '&v=custom:(id,uuid,' +
       'provider:(uuid,person:(uuid,display),attributes:(attributeType:(display),value,voided)),' +
@@ -34,6 +30,8 @@ export class SurgicalBlock extends Component {
       'person:(age,gender,birthdate)),' +
       'actualStartDatetime,actualEndDatetime,status,notes,sortWeight,' +
       'bedNumber,bedLocation,surgicalAppointmentAttributes,patientObservations))';
+
+    const url = Util.resolveUrlTokens(properties.URL || defaultUrl);
 
     httpInterceptor
       .get(url)

--- a/src/components/SurgicalBlock.jsx
+++ b/src/components/SurgicalBlock.jsx
@@ -37,13 +37,16 @@ export class SurgicalBlock extends Component {
       .get(url)
       .then((data) => {
         const { patientUuid } = this.props;
-        const blocks = (data.results || []).filter((block) =>
-          !patientUuid ||
-          (block.surgicalAppointments || []).some((appt) =>
-            appt.patient && appt.patient.uuid === patientUuid
-          )
-        );
-        this.setState({ surgeryOptions: this._formatSurgeryOptions(blocks) });
+        const surgeryOptions = [];
+        (data.results || []).forEach((block) => {
+          (block.surgicalAppointments || []).forEach((surgicalAppointment) => {
+            if (!patientUuid || (surgicalAppointment.patient &&
+                surgicalAppointment.patient.uuid === patientUuid)) {
+              surgeryOptions.push(this._formatSurgeryOption(block, surgicalAppointment));
+            }
+          });
+        });
+        this.setState({ surgeryOptions });
       })
       .catch(() => {
         this.props.showNotification('Failed to fetch surgical blocks', Constants.messageType.error);
@@ -55,13 +58,11 @@ export class SurgicalBlock extends Component {
     this.props.onChange({ value: updatedValue, errors });
   }
 
-  _formatSurgeryOptions(blocks) {
-    return blocks.map((block) => {
-      const date = this._formatDate(block.startDatetime);
-      const surgeon = block.provider && block.provider.person
-        ? block.provider.person.display : '';
-      return { id: block.uuid, name: `${date} - ${surgeon}` };
-    });
+  _formatSurgeryOption(block, surgicalAppointment) {
+    const date = this._formatDate(block.startDatetime);
+    const surgeon = block.provider && block.provider.person
+      ? block.provider.person.display : '';
+    return { id: surgicalAppointment.uuid, name: `${date} - ${surgeon}` };
   }
 
   _formatDate(datetime) {
@@ -69,8 +70,8 @@ export class SurgicalBlock extends Component {
     return moment(datetime).format('DD/MM/YYYY');
   }
 
-  _getValue(val) {
-    return find(this.state.surgeryOptions, (option) => option.id === val);
+  _getValue(savedValue) {
+    return find(this.state.surgeryOptions, (option) => option.id === savedValue);
   }
 
   render() {

--- a/src/components/SurgicalBlock.jsx
+++ b/src/components/SurgicalBlock.jsx
@@ -27,9 +27,12 @@ export class SurgicalBlock extends Component {
       `&startDatetime=${startDatetime}` +
       `&endDatetime=${endDatetime}` +
       '&includeVoided=false' +
-      '&v=custom:(id,uuid,provider:(uuid,person:(uuid,display),attributes:(attributeType:(display),value,voided)),' +
-      'location:(uuid,name),startDatetime,endDatetime,surgicalAppointments:(id,uuid,patient:(uuid,display,' +
-      'person:(age,gender,birthdate)),actualStartDatetime,actualEndDatetime,status,notes,sortWeight,' +
+      '&v=custom:(id,uuid,' +
+      'provider:(uuid,person:(uuid,display),attributes:(attributeType:(display),value,voided)),' +
+      'location:(uuid,name),startDatetime,endDatetime,' +
+      'surgicalAppointments:(id,uuid,patient:(uuid,display,' +
+      'person:(age,gender,birthdate)),' +
+      'actualStartDatetime,actualEndDatetime,status,notes,sortWeight,' +
       'bedNumber,bedLocation,surgicalAppointmentAttributes,patientObservations))';
 
     httpInterceptor
@@ -65,11 +68,7 @@ export class SurgicalBlock extends Component {
 
   _formatDate(datetime) {
     if (!datetime) return '';
-    const d = new Date(datetime);
-    const day = String(d.getDate()).padStart(2, '0');
-    const month = String(d.getMonth() + 1).padStart(2, '0');
-    const year = d.getFullYear();
-    return `${day}/${month}/${year}`;
+    return moment(datetime).format('DD/MM/YYYY');
   }
 
   _getValue(val) {

--- a/src/components/SurgicalBlock.jsx
+++ b/src/components/SurgicalBlock.jsx
@@ -1,0 +1,118 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import moment from 'moment';
+import ComponentStore from 'src/helpers/componentStore';
+import { AutoComplete } from 'src/components/AutoComplete.jsx';
+import { httpInterceptor } from 'src/helpers/httpInterceptor';
+import Constants from 'src/constants';
+import find from 'lodash/find';
+
+export class SurgicalBlock extends Component {
+
+  constructor(props) {
+    super(props);
+    this.state = { surgeryOptions: [] };
+    this.onValueChange = this.onValueChange.bind(this);
+  }
+
+  componentDidMount() {
+    const now = moment();
+    const oneMonthAgo = moment().subtract(1, 'months').startOf('day');
+
+    const startDatetime = encodeURIComponent(oneMonthAgo.format('YYYY-MM-DDTHH:mm:ss.SSSZZ'));
+    const endDatetime = encodeURIComponent(now.endOf('day').format('YYYY-MM-DDTHH:mm:ss.SSSZZ'));
+
+    const url = '/openmrs/ws/rest/v1/surgicalBlock' +
+      '?activeBlocks=true' +
+      `&startDatetime=${startDatetime}` +
+      `&endDatetime=${endDatetime}` +
+      '&includeVoided=false' +
+      '&v=custom:(id,uuid,provider:(uuid,person:(uuid,display),attributes:(attributeType:(display),value,voided)),' +
+      'location:(uuid,name),startDatetime,endDatetime,surgicalAppointments:(id,uuid,patient:(uuid,display,' +
+      'person:(age,gender,birthdate)),actualStartDatetime,actualEndDatetime,status,notes,sortWeight,' +
+      'bedNumber,bedLocation,surgicalAppointmentAttributes,patientObservations))';
+
+    httpInterceptor
+      .get(url)
+      .then((data) => {
+        const { patientUuid } = this.props;
+        const blocks = (data.results || []).filter((block) =>
+          !patientUuid ||
+          (block.surgicalAppointments || []).some((appt) =>
+            appt.patient && appt.patient.uuid === patientUuid
+          )
+        );
+        this.setState({ surgeryOptions: this._formatSurgeryOptions(blocks) });
+      })
+      .catch(() => {
+        this.props.showNotification('Failed to fetch surgical blocks', Constants.messageType.error);
+      });
+  }
+
+  onValueChange(value, errors) {
+    const updatedValue = value ? value.id : undefined;
+    this.props.onChange({ value: updatedValue, errors });
+  }
+
+  _formatSurgeryOptions(blocks) {
+    return blocks.map((block) => {
+      const date = this._formatDate(block.startDatetime);
+      const surgeon = block.provider && block.provider.person
+        ? block.provider.person.display : '';
+      return { id: block.uuid, name: `${date} - ${surgeon}` };
+    });
+  }
+
+  _formatDate(datetime) {
+    if (!datetime) return '';
+    const d = new Date(datetime);
+    const day = String(d.getDate()).padStart(2, '0');
+    const month = String(d.getMonth() + 1).padStart(2, '0');
+    const year = d.getFullYear();
+    return `${day}/${month}/${year}`;
+  }
+
+  _getValue(val) {
+    return find(this.state.surgeryOptions, (option) => option.id === val);
+  }
+
+  render() {
+    const value = this.props.value ? this._getValue(this.props.value) : undefined;
+    const { properties } = this.props;
+    const isSearchable = (properties.style === 'autocomplete');
+    const minimumInput = isSearchable ? 2 : 0;
+    return (
+      <AutoComplete {...this.props}
+        asynchronous={false}
+        minimumInput={minimumInput}
+        onValueChange={this.onValueChange}
+        options={this.state.surgeryOptions}
+        searchable={isSearchable}
+        value={value}
+      />
+    );
+  }
+}
+
+SurgicalBlock.propTypes = {
+  addMore: PropTypes.bool,
+  enabled: PropTypes.bool,
+  formFieldPath: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  patientUuid: PropTypes.string,
+  properties: PropTypes.object.isRequired,
+  showNotification: PropTypes.func.isRequired,
+  validate: PropTypes.bool.isRequired,
+  validations: PropTypes.array.isRequired,
+  value: PropTypes.string,
+};
+
+SurgicalBlock.defaultProps = {
+  autofocus: false,
+  enabled: true,
+  labelKey: 'name',
+  valueKey: 'id',
+  searchable: false,
+};
+
+ComponentStore.registerComponent('SurgicalBlockObsHandler', SurgicalBlock);

--- a/src/components/designer/SurgicalBlock.jsx
+++ b/src/components/designer/SurgicalBlock.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
+import { Util } from 'src/helpers/Util';
 import ComponentStore from 'src/helpers/componentStore';
 import { AutoComplete } from 'src/components/AutoComplete.jsx';
 import { httpInterceptor } from 'src/helpers/httpInterceptor';
@@ -13,17 +14,11 @@ export class SurgicalBlockDesigner extends Component {
   }
 
   componentDidMount() {
-    const { setError } = this.props;
-    const now = moment();
-    const oneMonthAgo = moment().subtract(1, 'months').startOf('day');
-
-    const startDatetime = encodeURIComponent(oneMonthAgo.format('YYYY-MM-DDTHH:mm:ss.SSSZZ'));
-    const endDatetime = encodeURIComponent(now.endOf('day').format('YYYY-MM-DDTHH:mm:ss.SSSZZ'));
-
-    const url = '/openmrs/ws/rest/v1/surgicalBlock' +
+    const { metadata: { properties }, setError } = this.props;
+    const defaultUrl = '/openmrs/ws/rest/v1/surgicalBlock' +
       '?activeBlocks=true' +
-      `&startDatetime=${startDatetime}` +
-      `&endDatetime=${endDatetime}` +
+      '&startDatetime={NOW-30d}' +
+      '&endDatetime={NOW}' +
       '&includeVoided=false' +
       '&v=custom:(id,uuid,' +
       'provider:(uuid,person:(uuid,display),attributes:(attributeType:(display),value,voided)),' +
@@ -32,6 +27,8 @@ export class SurgicalBlockDesigner extends Component {
       'person:(age,gender,birthdate)),' +
       'actualStartDatetime,actualEndDatetime,status,notes,sortWeight,' +
       'bedNumber,bedLocation,surgicalAppointmentAttributes,patientObservations))';
+
+    const url = Util.resolveUrlTokens(properties.URL || defaultUrl);
 
     httpInterceptor
       .get(url)
@@ -91,6 +88,20 @@ const descriptor = {
         name: 'properties',
         dataType: 'complex',
         attributes: [
+          {
+            name: 'URL',
+            dataType: 'string',
+            defaultValue: '/openmrs/ws/rest/v1/surgicalBlock?activeBlocks=true' +
+              '&startDatetime={NOW-30d}&endDatetime={NOW}&includeVoided=false' +
+              '&v=custom:(id,uuid,provider:(uuid,person:(uuid,display),' +
+              'attributes:(attributeType:(display),value,voided)),location:(uuid,name),' +
+              'startDatetime,endDatetime,' +
+              'surgicalAppointments:(id,uuid,patient:(uuid,display,' +
+              'person:(age,gender,birthdate)),' +
+              'actualStartDatetime,actualEndDatetime,status,notes,sortWeight,' +
+              'bedNumber,bedLocation,surgicalAppointmentAttributes,patientObservations))',
+            elementType: 'text',
+          },
           {
             name: 'style',
             dataType: 'string',

--- a/src/components/designer/SurgicalBlock.jsx
+++ b/src/components/designer/SurgicalBlock.jsx
@@ -25,17 +25,19 @@ export class SurgicalBlockDesigner extends Component {
       `&startDatetime=${startDatetime}` +
       `&endDatetime=${endDatetime}` +
       '&includeVoided=false' +
-      '&v=custom:(id,uuid,provider:(uuid,person:(uuid,display),attributes:(attributeType:(display),value,voided)),' +
-      'location:(uuid,name),startDatetime,endDatetime,surgicalAppointments:(id,uuid,patient:(uuid,display,' +
-      'person:(age,gender,birthdate)),actualStartDatetime,actualEndDatetime,status,notes,sortWeight,' +
+      '&v=custom:(id,uuid,' +
+      'provider:(uuid,person:(uuid,display),attributes:(attributeType:(display),value,voided)),' +
+      'location:(uuid,name),startDatetime,endDatetime,' +
+      'surgicalAppointments:(id,uuid,patient:(uuid,display,' +
+      'person:(age,gender,birthdate)),' +
+      'actualStartDatetime,actualEndDatetime,status,notes,sortWeight,' +
       'bedNumber,bedLocation,surgicalAppointmentAttributes,patientObservations))';
 
     httpInterceptor
       .get(url)
       .then((data) => {
         const options = (data.results || []).map((block) => {
-          const d = new Date(block.startDatetime);
-          const date = `${String(d.getDate()).padStart(2, '0')}/${String(d.getMonth() + 1).padStart(2, '0')}/${d.getFullYear()}`;
+          const date = moment(block.startDatetime).format('DD/MM/YYYY');
           const surgeon = block.provider && block.provider.person
             ? block.provider.person.display : '';
           return { id: block.uuid, name: `${date} - ${surgeon}` };

--- a/src/components/designer/SurgicalBlock.jsx
+++ b/src/components/designer/SurgicalBlock.jsx
@@ -1,0 +1,105 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import moment from 'moment';
+import ComponentStore from 'src/helpers/componentStore';
+import { AutoComplete } from 'src/components/AutoComplete.jsx';
+import { httpInterceptor } from 'src/helpers/httpInterceptor';
+
+export class SurgicalBlockDesigner extends Component {
+
+  constructor(props) {
+    super(props);
+    this.state = { surgeryOptions: [] };
+  }
+
+  componentDidMount() {
+    const { setError } = this.props;
+    const now = moment();
+    const oneMonthAgo = moment().subtract(1, 'months').startOf('day');
+
+    const startDatetime = encodeURIComponent(oneMonthAgo.format('YYYY-MM-DDTHH:mm:ss.SSSZZ'));
+    const endDatetime = encodeURIComponent(now.endOf('day').format('YYYY-MM-DDTHH:mm:ss.SSSZZ'));
+
+    const url = '/openmrs/ws/rest/v1/surgicalBlock' +
+      '?activeBlocks=true' +
+      `&startDatetime=${startDatetime}` +
+      `&endDatetime=${endDatetime}` +
+      '&includeVoided=false' +
+      '&v=custom:(id,uuid,provider:(uuid,person:(uuid,display),attributes:(attributeType:(display),value,voided)),' +
+      'location:(uuid,name),startDatetime,endDatetime,surgicalAppointments:(id,uuid,patient:(uuid,display,' +
+      'person:(age,gender,birthdate)),actualStartDatetime,actualEndDatetime,status,notes,sortWeight,' +
+      'bedNumber,bedLocation,surgicalAppointmentAttributes,patientObservations))';
+
+    httpInterceptor
+      .get(url)
+      .then((data) => {
+        const options = (data.results || []).map((block) => {
+          const d = new Date(block.startDatetime);
+          const date = `${String(d.getDate()).padStart(2, '0')}/${String(d.getMonth() + 1).padStart(2, '0')}/${d.getFullYear()}`;
+          const surgeon = block.provider && block.provider.person
+            ? block.provider.person.display : '';
+          return { id: block.uuid, name: `${date} - ${surgeon}` };
+        });
+        this.setState({ surgeryOptions: options });
+      })
+      .catch(() => {
+        if (setError) {
+          setError({ message: 'Invalid Surgical Block URL' });
+        }
+      });
+  }
+
+  render() {
+    const { properties } = this.props.metadata;
+    const isSearchable = (properties.style === 'autocomplete');
+    const minimumInput = isSearchable ? 2 : 0;
+    return (
+      <AutoComplete
+        asynchronous={false}
+        enabled
+        labelKey="name"
+        minimumInput={minimumInput}
+        options={this.state.surgeryOptions}
+        searchable={isSearchable}
+        valueKey="id"
+      />
+    );
+  }
+}
+
+SurgicalBlockDesigner.propTypes = {
+  metadata: PropTypes.shape({
+    concept: PropTypes.object.isRequired,
+    displayType: PropTypes.string,
+    id: PropTypes.string.isRequired,
+    properties: PropTypes.object.isRequired,
+    type: PropTypes.string,
+  }),
+  setError: PropTypes.func,
+};
+
+const descriptor = {
+  control: SurgicalBlockDesigner,
+  designProperties: {
+    isTopLevelComponent: false,
+  },
+  metadata: {
+    attributes: [
+      {
+        name: 'properties',
+        dataType: 'complex',
+        attributes: [
+          {
+            name: 'style',
+            dataType: 'string',
+            defaultValue: 'dropdown',
+            elementType: 'dropdown',
+            options: ['autocomplete', 'dropdown'],
+          },
+        ],
+      },
+    ],
+  },
+};
+
+ComponentStore.registerDesignerComponent('SurgicalBlockObsHandler', descriptor);

--- a/src/helpers/Util.js
+++ b/src/helpers/Util.js
@@ -1,4 +1,6 @@
 
+import moment from 'moment';
+
 export class Util {
   static toInt(obj) {
     return Number.parseInt(obj, 10);
@@ -89,6 +91,25 @@ export class Util {
       const error = new Error(response.statusText);
       error.response = response;
       throw error;
+    });
+  }
+
+  static resolveUrlTokens(url) {
+    const DATE_FORMAT = 'YYYY-MM-DDTHH:mm:ss.SSSZZ';
+    const UNITS = { d: 'days' };
+    return url.replace(/\{([^}]+)\}/g, (match, token) => {
+      if (token === 'NOW') {
+        return encodeURIComponent(moment().endOf('day').format(DATE_FORMAT));
+      }
+      const relativeMatch = token.match(/^NOW-(\d+)(d)$/);
+      if (relativeMatch) {
+        const amount = parseInt(relativeMatch[1], 10);
+        const unit = UNITS[relativeMatch[2]];
+        return encodeURIComponent(
+          moment().subtract(amount, unit).startOf('day').format(DATE_FORMAT)
+        );
+      }
+      return match;
     });
   }
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -19,6 +19,7 @@ export { Image } from 'components/Image.jsx';
 export { Video } from 'components/Video.jsx';
 export { Location } from 'components/Location.jsx';
 export { Provider } from 'components/Provider.jsx';
+export { SurgicalBlock } from 'components/SurgicalBlock.jsx';
 export { FreeTextAutoComplete } from 'components/FreeTextAutoComplete.jsx';
 
 //  -----------designer components------------------
@@ -45,6 +46,7 @@ export { ImageDesigner } from 'components/designer/Image.jsx';
 export { VideoDesigner } from 'components/designer/Video.jsx';
 export { LocationDesigner } from 'components/designer/Location.jsx';
 export { ProviderDesigner } from 'components/designer/Provider.jsx';
+export { SurgicalBlockDesigner } from 'components/designer/SurgicalBlock.jsx';
 
 // -------------------------- helpers ---------------------
 

--- a/test/components/SurgicalBlock.spec.js
+++ b/test/components/SurgicalBlock.spec.js
@@ -91,6 +91,45 @@ describe('SurgicalBlock', () => {
     expect(wrapper.find('AutoComplete')).to.have.prop('value').to.eql(expectedOptions[0]);
   });
 
+  it('should use properties.URL with resolved tokens when provided', () => {
+    surgicalBlockStub.returnsPromise().resolves(surgicalBlockData);
+    mount(
+      <SurgicalBlock
+        formFieldPath={formFieldPath}
+        onChange={onChangeSpy}
+        properties={{ style: 'autocomplete',
+          URL: '/custom/surgicalBlock?start={NOW-60d}&end={NOW}' }}
+        showNotification={showNotificationSpy}
+        validate={false}
+        validations={[]}
+      />
+    );
+    const calledUrl = surgicalBlockStub.getCall(0).args[0];
+    expect(calledUrl).to.include('/custom/surgicalBlock');
+    expect(calledUrl).to.include('start=');
+    expect(calledUrl).to.include('end=');
+    expect(calledUrl).to.not.include('{NOW-60d}');
+    expect(calledUrl).to.not.include('{NOW}');
+  });
+
+  it('should use the default URL with resolved tokens when properties.URL is not set', () => {
+    surgicalBlockStub.returnsPromise().resolves(surgicalBlockData);
+    mount(
+      <SurgicalBlock
+        formFieldPath={formFieldPath}
+        onChange={onChangeSpy}
+        properties={{ style: 'autocomplete' }}
+        showNotification={showNotificationSpy}
+        validate={false}
+        validations={[]}
+      />
+    );
+    const calledUrl = surgicalBlockStub.getCall(0).args[0];
+    expect(calledUrl).to.include('/openmrs/ws/rest/v1/surgicalBlock');
+    expect(calledUrl).to.not.include('{NOW-30d}');
+    expect(calledUrl).to.not.include('{NOW}');
+  });
+
   it('should call the surgical block API with dynamic date parameters', () => {
     surgicalBlockStub.returnsPromise().resolves(surgicalBlockData);
     mount(

--- a/test/components/SurgicalBlock.spec.js
+++ b/test/components/SurgicalBlock.spec.js
@@ -38,8 +38,8 @@ describe('SurgicalBlock', () => {
   };
 
   const expectedOptions = [
-    { id: 'block-uuid-1', name: '15/05/2026 - Dr. Smith' },
-    { id: 'block-uuid-2', name: '20/05/2026 - Dr. Jones' },
+    { id: 'appt-uuid-1', name: '15/05/2026 - Dr. Smith' },
+    { id: 'appt-uuid-2', name: '20/05/2026 - Dr. Jones' },
   ];
 
   beforeEach(() => {
@@ -83,7 +83,7 @@ describe('SurgicalBlock', () => {
         showNotification={showNotificationSpy}
         validate={false}
         validations={[]}
-        value={'block-uuid-1'}
+        value={'appt-uuid-1'}
       />
     );
     expect(wrapper.find('AutoComplete')).to.have.prop('searchable').to.eql(false);
@@ -165,7 +165,7 @@ describe('SurgicalBlock', () => {
       />
     );
     expect(wrapper.find('AutoComplete')).to.have.prop('options')
-      .to.eql([{ id: 'block-uuid-1', name: '15/05/2026 - Dr. Smith' }]);
+      .to.eql([{ id: 'appt-uuid-1', name: '15/05/2026 - Dr. Smith' }]);
   });
 
   it('should show all blocks when patient prop is not provided', () => {
@@ -229,7 +229,7 @@ describe('SurgicalBlock', () => {
     );
     const onValueChange = wrapper.find('AutoComplete').props().onValueChange;
     onValueChange(expectedOptions[0], []);
-    sinon.assert.calledOnce(onChangeSpy.withArgs({ value: 'block-uuid-1', errors: [] }));
+    sinon.assert.calledOnce(onChangeSpy.withArgs({ value: 'appt-uuid-1', errors: [] }));
   });
 
   it('should return undefined when selection is cleared', () => {

--- a/test/components/SurgicalBlock.spec.js
+++ b/test/components/SurgicalBlock.spec.js
@@ -1,0 +1,212 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import chaiEnzyme from 'chai-enzyme';
+import chai, { expect } from 'chai';
+import { SurgicalBlock } from 'components/SurgicalBlock.jsx';
+import sinon from 'sinon';
+import { httpInterceptor } from 'src/helpers/httpInterceptor';
+import Constants from 'src/constants';
+
+chai.use(chaiEnzyme());
+const sinonStubPromise = require('sinon-stub-promise');
+sinonStubPromise(sinon);
+
+describe('SurgicalBlock', () => {
+  let wrapper;
+  let surgicalBlockStub;
+  let onChangeSpy;
+  let showNotificationSpy;
+
+  const formFieldPath = 'test1.1/1-0';
+  const properties = { style: 'autocomplete' };
+
+  const surgicalBlockData = {
+    results: [
+      {
+        uuid: 'block-uuid-1',
+        startDatetime: '2026-05-15T08:00:00.000+0000',
+        provider: { person: { display: 'Dr. Smith' } },
+        surgicalAppointments: [{ uuid: 'appt-uuid-1', patient: { uuid: 'patient-uuid-1' } }],
+      },
+      {
+        uuid: 'block-uuid-2',
+        startDatetime: '2026-05-20T10:00:00.000+0000',
+        provider: { person: { display: 'Dr. Jones' } },
+        surgicalAppointments: [{ uuid: 'appt-uuid-2', patient: { uuid: 'patient-uuid-2' } }],
+      },
+    ],
+  };
+
+  const expectedOptions = [
+    { id: 'block-uuid-1', name: '15/05/2026 - Dr. Smith' },
+    { id: 'block-uuid-2', name: '20/05/2026 - Dr. Jones' },
+  ];
+
+  beforeEach(() => {
+    onChangeSpy = sinon.spy();
+    showNotificationSpy = sinon.spy();
+    surgicalBlockStub = sinon.stub(httpInterceptor, 'get');
+  });
+
+  afterEach(() => surgicalBlockStub.restore());
+
+  it('should render the SurgicalBlock autocomplete component with formatted options', () => {
+    surgicalBlockStub.returnsPromise().resolves(surgicalBlockData);
+    wrapper = mount(
+      <SurgicalBlock
+        addMore
+        formFieldPath={formFieldPath}
+        onChange={onChangeSpy}
+        properties={properties}
+        showNotification={showNotificationSpy}
+        validate={false}
+        validations={[]}
+      />
+    );
+    expect(wrapper).to.have.exactly(1).descendants('AutoComplete');
+    expect(wrapper.find('AutoComplete')).to.have.prop('asynchronous').to.eql(false);
+    expect(wrapper.find('AutoComplete')).to.have.prop('options').to.eql(expectedOptions);
+    expect(wrapper.find('AutoComplete')).to.have.prop('searchable').to.eql(true);
+    expect(wrapper.find('AutoComplete')).to.have.prop('minimumInput').to.eql(2);
+    expect(wrapper.find('AutoComplete')).to.have.prop('labelKey').to.eql('name');
+    expect(wrapper.find('AutoComplete')).to.have.prop('valueKey').to.eql('id');
+  });
+
+  it('should render as dropdown when style is not autocomplete', () => {
+    surgicalBlockStub.returnsPromise().resolves(surgicalBlockData);
+    wrapper = mount(
+      <SurgicalBlock
+        addMore
+        formFieldPath={formFieldPath}
+        onChange={onChangeSpy}
+        properties={{ style: 'dropdown' }}
+        showNotification={showNotificationSpy}
+        validate={false}
+        validations={[]}
+        value={'block-uuid-1'}
+      />
+    );
+    expect(wrapper.find('AutoComplete')).to.have.prop('searchable').to.eql(false);
+    expect(wrapper.find('AutoComplete')).to.have.prop('minimumInput').to.eql(0);
+    expect(wrapper.find('AutoComplete')).to.have.prop('value').to.eql(expectedOptions[0]);
+  });
+
+  it('should call the surgical block API with dynamic date parameters', () => {
+    surgicalBlockStub.returnsPromise().resolves(surgicalBlockData);
+    mount(
+      <SurgicalBlock
+        formFieldPath={formFieldPath}
+        onChange={onChangeSpy}
+        properties={properties}
+        showNotification={showNotificationSpy}
+        validate={false}
+        validations={[]}
+      />
+    );
+    sinon.assert.calledOnce(surgicalBlockStub);
+    const calledUrl = surgicalBlockStub.getCall(0).args[0];
+    expect(calledUrl).to.include('/openmrs/ws/rest/v1/surgicalBlock');
+    expect(calledUrl).to.include('activeBlocks=true');
+    expect(calledUrl).to.include('startDatetime=');
+    expect(calledUrl).to.include('endDatetime=');
+    expect(calledUrl).to.include('includeVoided=false');
+  });
+
+  it('should filter blocks by patient uuid when patient prop is provided', () => {
+    surgicalBlockStub.returnsPromise().resolves(surgicalBlockData);
+    wrapper = mount(
+      <SurgicalBlock
+        formFieldPath={formFieldPath}
+        onChange={onChangeSpy}
+        patientUuid={'patient-uuid-1'}
+        properties={properties}
+        showNotification={showNotificationSpy}
+        validate={false}
+        validations={[]}
+      />
+    );
+    expect(wrapper.find('AutoComplete')).to.have.prop('options')
+      .to.eql([{ id: 'block-uuid-1', name: '15/05/2026 - Dr. Smith' }]);
+  });
+
+  it('should show all blocks when patient prop is not provided', () => {
+    surgicalBlockStub.returnsPromise().resolves(surgicalBlockData);
+    wrapper = mount(
+      <SurgicalBlock
+        formFieldPath={formFieldPath}
+        onChange={onChangeSpy}
+        properties={properties}
+        showNotification={showNotificationSpy}
+        validate={false}
+        validations={[]}
+      />
+    );
+    expect(wrapper.find('AutoComplete')).to.have.prop('options').to.eql(expectedOptions);
+  });
+
+  it('should handle empty results gracefully', () => {
+    surgicalBlockStub.returnsPromise().resolves({ results: [] });
+    wrapper = mount(
+      <SurgicalBlock
+        formFieldPath={formFieldPath}
+        onChange={onChangeSpy}
+        properties={properties}
+        showNotification={showNotificationSpy}
+        validate={false}
+        validations={[]}
+      />
+    );
+    expect(wrapper.find('AutoComplete')).to.have.prop('options').to.eql([]);
+  });
+
+  it('should show notification when API call fails', () => {
+    surgicalBlockStub.returnsPromise().rejects('error');
+    mount(
+      <SurgicalBlock
+        formFieldPath={formFieldPath}
+        onChange={onChangeSpy}
+        properties={properties}
+        showNotification={showNotificationSpy}
+        validate={false}
+        validations={[]}
+      />
+    );
+    sinon.assert.calledOnce(
+      showNotificationSpy.withArgs('Failed to fetch surgical blocks', Constants.messageType.error)
+    );
+  });
+
+  it('should return the selected block uuid on value change', () => {
+    surgicalBlockStub.returnsPromise().resolves(surgicalBlockData);
+    wrapper = mount(
+      <SurgicalBlock
+        formFieldPath={formFieldPath}
+        onChange={onChangeSpy}
+        properties={properties}
+        showNotification={showNotificationSpy}
+        validate={false}
+        validations={[]}
+      />
+    );
+    const onValueChange = wrapper.find('AutoComplete').props().onValueChange;
+    onValueChange(expectedOptions[0], []);
+    sinon.assert.calledOnce(onChangeSpy.withArgs({ value: 'block-uuid-1', errors: [] }));
+  });
+
+  it('should return undefined when selection is cleared', () => {
+    surgicalBlockStub.returnsPromise().resolves(surgicalBlockData);
+    wrapper = mount(
+      <SurgicalBlock
+        formFieldPath={formFieldPath}
+        onChange={onChangeSpy}
+        properties={properties}
+        showNotification={showNotificationSpy}
+        validate={false}
+        validations={[]}
+      />
+    );
+    const onValueChange = wrapper.find('AutoComplete').props().onValueChange;
+    onValueChange(null, []);
+    sinon.assert.calledOnce(onChangeSpy.withArgs({ value: undefined, errors: [] }));
+  });
+});

--- a/test/components/designer/SurgicalBlock.spec.js
+++ b/test/components/designer/SurgicalBlock.spec.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import chaiEnzyme from 'chai-enzyme';
+import chai, { expect } from 'chai';
+import { SurgicalBlockDesigner } from 'components/designer/SurgicalBlock.jsx';
+import sinon from 'sinon';
+import { httpInterceptor } from 'src/helpers/httpInterceptor';
+
+chai.use(chaiEnzyme());
+const sinonStubPromise = require('sinon-stub-promise');
+sinonStubPromise(sinon);
+
+describe('SurgicalBlockDesigner', () => {
+  let wrapper;
+  let metadata;
+  let surgicalBlockStub;
+
+  const surgicalBlockData = {
+    results: [
+      {
+        uuid: 'block-uuid-1',
+        startDatetime: '2026-05-15T08:00:00.000+0000',
+        provider: { person: { display: 'Dr. Smith' } },
+      },
+    ],
+  };
+
+  const expectedOptions = [
+    { id: 'block-uuid-1', name: '15/05/2026 - Dr. Smith' },
+  ];
+
+  beforeEach(() => {
+    metadata = {
+      concept: {
+        name: 'Select Surgery',
+        uuid: 'someUuid',
+        datatype: 'Complex',
+        handler: 'SurgicalBlockObsHandler',
+      },
+      type: 'obsControl',
+      id: 'someId',
+      properties: { style: 'autocomplete' },
+    };
+    surgicalBlockStub = sinon.stub(httpInterceptor, 'get');
+  });
+
+  afterEach(() => surgicalBlockStub.restore());
+
+  it('should render the surgical block designer autocomplete component', () => {
+    surgicalBlockStub.returnsPromise().resolves(surgicalBlockData);
+    wrapper = mount(<SurgicalBlockDesigner metadata={metadata} />);
+    expect(wrapper).to.have.exactly(1).descendants('AutoComplete');
+    expect(wrapper.find('AutoComplete')).to.have.prop('asynchronous').to.eql(false);
+    expect(wrapper.find('AutoComplete')).to.have.prop('options').to.eql(expectedOptions);
+    expect(wrapper.find('AutoComplete')).to.have.prop('searchable').to.eql(true);
+    expect(wrapper.find('AutoComplete')).to.have.prop('minimumInput').to.eql(2);
+    expect(wrapper.find('AutoComplete')).to.have.prop('labelKey').to.eql('name');
+    expect(wrapper.find('AutoComplete')).to.have.prop('valueKey').to.eql('id');
+  });
+
+  it('should render the surgical block designer dropdown component', () => {
+    surgicalBlockStub.returnsPromise().resolves(surgicalBlockData);
+    metadata.properties.style = 'dropdown';
+    wrapper = mount(<SurgicalBlockDesigner metadata={metadata} />);
+    expect(wrapper).to.have.exactly(1).descendants('AutoComplete');
+    expect(wrapper.find('AutoComplete')).to.have.prop('options').to.eql(expectedOptions);
+    expect(wrapper.find('AutoComplete')).to.have.prop('searchable').to.eql(false);
+    expect(wrapper.find('AutoComplete')).to.have.prop('minimumInput').to.eql(0);
+    expect(wrapper.find('AutoComplete')).to.have.prop('labelKey').to.eql('name');
+    expect(wrapper.find('AutoComplete')).to.have.prop('valueKey').to.eql('id');
+  });
+
+  it('should call setError when API call fails', () => {
+    const setErrorSpy = sinon.spy();
+    surgicalBlockStub.returnsPromise().rejects('error');
+    wrapper = mount(<SurgicalBlockDesigner metadata={metadata} setError={setErrorSpy} />);
+    sinon.assert.calledOnce(setErrorSpy.withArgs({ message: 'Invalid Surgical Block URL' }));
+  });
+});

--- a/test/components/designer/SurgicalBlock.spec.js
+++ b/test/components/designer/SurgicalBlock.spec.js
@@ -70,6 +70,25 @@ describe('SurgicalBlockDesigner', () => {
     expect(wrapper.find('AutoComplete')).to.have.prop('valueKey').to.eql('id');
   });
 
+  it('should use properties.URL with resolved tokens when provided', () => {
+    surgicalBlockStub.returnsPromise().resolves(surgicalBlockData);
+    metadata.properties.URL = '/custom/surgicalBlock?start={NOW-40d}&end={NOW}';
+    mount(<SurgicalBlockDesigner metadata={metadata} />);
+    const calledUrl = surgicalBlockStub.getCall(0).args[0];
+    expect(calledUrl).to.include('/custom/surgicalBlock');
+    expect(calledUrl).to.not.include('{NOW-40d}');
+    expect(calledUrl).to.not.include('{NOW}');
+  });
+
+  it('should use default URL with resolved tokens when properties.URL is not set', () => {
+    surgicalBlockStub.returnsPromise().resolves(surgicalBlockData);
+    mount(<SurgicalBlockDesigner metadata={metadata} />);
+    const calledUrl = surgicalBlockStub.getCall(0).args[0];
+    expect(calledUrl).to.include('/openmrs/ws/rest/v1/surgicalBlock');
+    expect(calledUrl).to.not.include('{NOW-30d}');
+    expect(calledUrl).to.not.include('{NOW}');
+  });
+
   it('should call setError when API call fails', () => {
     const setErrorSpy = sinon.spy();
     surgicalBlockStub.returnsPromise().rejects('error');

--- a/test/helpers/Util.spec.js
+++ b/test/helpers/Util.spec.js
@@ -3,6 +3,7 @@ import chai, { expect } from 'chai';
 import { Util } from '../../src/helpers/Util';
 import fetchMock from 'fetch-mock';
 import sinon from 'sinon';
+import moment from 'moment';
 
 chai.use(chaiEnzyme());
 
@@ -122,6 +123,71 @@ describe('Util', () => {
           expect(err.response.status).to.eql(404);
           done();
         });
+    });
+  });
+
+  describe('Util.resolveUrlTokens', () => {
+    const DATE_FORMAT = 'YYYY-MM-DDTHH:mm:ss.SSSZZ';
+    let clock;
+
+    beforeEach(() => {
+      clock = sinon.useFakeTimers(new Date('2026-06-01T12:00:00.000Z').getTime());
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    it('should replace {NOW} with end of current day encoded', () => {
+      const url = 'http://example.com?end={NOW}';
+      const result = Util.resolveUrlTokens(url);
+      const expected = encodeURIComponent(moment().endOf('day').format(DATE_FORMAT));
+      expect(result).to.equal(`http://example.com?end=${expected}`);
+    });
+
+    it('should replace {NOW-30d} with start of day 30 days ago encoded', () => {
+      const url = 'http://example.com?start={NOW-30d}';
+      const result = Util.resolveUrlTokens(url);
+      const expected = encodeURIComponent(
+        moment().subtract(30, 'days').startOf('day').format(DATE_FORMAT)
+      );
+      expect(result).to.equal(`http://example.com?start=${expected}`);
+    });
+
+    it('should replace {NOW-Nd} with any number of days', () => {
+      const url = 'http://example.com?start={NOW-60d}';
+      const result = Util.resolveUrlTokens(url);
+      const expected = encodeURIComponent(
+        moment().subtract(60, 'days').startOf('day').format(DATE_FORMAT)
+      );
+      expect(result).to.equal(`http://example.com?start=${expected}`);
+    });
+
+
+    it('should replace both tokens in the same URL', () => {
+      const url = 'http://example.com?start={NOW-30d}&end={NOW}';
+      const result = Util.resolveUrlTokens(url);
+      const expectedStart = encodeURIComponent(
+        moment().subtract(30, 'days').startOf('day').format(DATE_FORMAT)
+      );
+      const expectedEnd = encodeURIComponent(moment().endOf('day').format(DATE_FORMAT));
+      expect(result).to.equal(`http://example.com?start=${expectedStart}&end=${expectedEnd}`);
+    });
+
+    it('should leave the URL unchanged when no tokens are present', () => {
+      const url = 'http://example.com?v=custom:(id,uuid)';
+      expect(Util.resolveUrlTokens(url)).to.equal(url);
+    });
+
+    it('should leave unknown tokens verbatim', () => {
+      const url = 'http://example.com?foo={UNKNOWN}';
+      expect(Util.resolveUrlTokens(url)).to.equal('http://example.com?foo={UNKNOWN}');
+    });
+
+    it('should percent-encode the + in timezone offset', () => {
+      const url = 'http://example.com?start={NOW-30d}';
+      const result = Util.resolveUrlTokens(url);
+      expect(result).to.not.include('+');
     });
   });
 


### PR DESCRIPTION
## What This Introduces

### Generic: Dynamic URL Token Resolver (`Util.resolveUrlTokens`)

A reusable utility method that resolves date tokens in any URL string at render time. Any form control that needs dynamic parameters in a configurable URL can use this.

**Supported tokens:**

| Token | Resolves to |
|-------|-------------|
| `{NOW}` | Current date, end of day, timezone-aware, URL-encoded |
| `{NOW-Nd}` | N days ago, start of day (e.g. `{NOW-30d}`, `{NOW-40d}`) |

> Only days (`d`) are supported. Weeks/months are intentionally excluded — the surgical block API is designed for short date windows. Support for wider units can be added when a new consumer with a compatible endpoint requires it.

### How to Use in Any Form Control

```js
import { Util } from 'src/helpers/Util';

componentDidMount() {
  const { properties } = this.props;
  const defaultUrl = '/openmrs/ws/rest/v1/someEndpoint?from={NOW-30d}&to={NOW}';
  const url = Util.resolveUrlTokens(properties.URL || defaultUrl);
  httpInterceptor.get(url).then(...);
}
```

The designer descriptor exposes `URL` as a text field — the form builder configures the full URL including tokens:

```js
{ name: 'URL', dataType: 'string', elementType: 'text',
  defaultValue: '/openmrs/ws/rest/v1/someEndpoint?from={NOW-30d}&to={NOW}' }
```

---

### Specific: `SurgicalBlockObsHandler`

Uses the token resolver to implement a "Select Surgery" dropdown for operative report forms.

**Data model:** A `SurgicalBlock` is a time slot with a provider. Each block can contain multiple surgeries (`SurgicalAppointment`). The saved value is `surgicalAppointment.uuid` — the unique identifier per surgery — not the block UUID.

**Default URL (used when `properties.URL` is not configured):**
```
/openmrs/ws/rest/v1/surgicalBlock?activeBlocks=true
  &startDatetime={NOW-30d}
  &endDatetime={NOW}
  &includeVoided=false
  &v=custom:(id,uuid,provider:(uuid,person:(uuid,display),...),surgicalAppointments:(...))
```

**Configuring a different date window** (e.g. 40 days) — edit the URL field in implementer-interface:
```
...&startDatetime={NOW-40d}&endDatetime={NOW}...
```

**All URL params are configurable** — `activeBlocks`, `includeVoided`, `v=custom` representation, even the base endpoint path. Only the date values stay dynamic via tokens.

Results are filtered client-side by `patientUuid` (passed through the form rendering chain via `Container → ObsControl`) — only the current patient's surgeries appear in the dropdown.

---

## Test Plan

- [ ] Add `Select Surgery` concept (Complex, `SurgicalBlockObsHandler`) to an operative report form via implementer-interface — verify `URL` text field appears in properties panel with token-based default
- [ ] Change `{NOW-30d}` to `{NOW-40d}` in the URL field, save and publish — verify API call uses 40-day window
- [ ] Open a patient's operative report form in clinical — verify dropdown shows only that patient's surgeries
- [ ] Verify that each surgery in a block appears as a separate dropdown option
- [ ] Verify form saves `surgicalAppointment.uuid` (not block UUID) on selection
- [ ] Unit tests: `SurgicalBlock.spec.js` (10 tests), `designer/SurgicalBlock.spec.js` (5 tests), `Util.spec.js` (7 new `resolveUrlTokens` tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)